### PR TITLE
pre 0.12.2 (hotfix)

### DIFF
--- a/internal/commands/cmdkick.go
+++ b/internal/commands/cmdkick.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -65,15 +64,12 @@ func (c *CmdKick) Exec(args *CommandArgs) error {
 		return err
 	}
 
-	fmt.Println(util.RolePosDiff(victim, authorMemb, args.Guild))
 	if util.RolePosDiff(victim, authorMemb, args.Guild) >= 0 {
 		msg, err := util.SendEmbedError(args.Session, args.Channel.ID,
 			"You can only kick members with lower permissions than yours.")
 		util.DeleteMessageLater(args.Session, msg, 8*time.Second)
 		return err
 	}
-
-	return errors.New("canceled")
 
 	repMsg := strings.Join(args.Args[1:], " ")
 	var repType int

--- a/internal/util/extensions.go
+++ b/internal/util/extensions.go
@@ -75,14 +75,14 @@ func RolePosDiff(m1 *discordgo.Member, m2 *discordgo.Member, g *discordgo.Guild)
 
 	for _, r := range m1.Roles {
 		p := rolePositions[r]
-		if p < m1MaxPos || m1MaxPos == -1 {
+		if p > m1MaxPos || m1MaxPos == -1 {
 			m1MaxPos = p
 		}
 	}
 
 	for _, r := range m2.Roles {
 		p := rolePositions[r]
-		if p < m2MaxPos || m2MaxPos == -1 {
+		if p > m2MaxPos || m2MaxPos == -1 {
 			m2MaxPos = p
 		}
 	}


### PR DESCRIPTION
- fix `kick` command (`canceled` error)
- fix wrong permission check of `kick`, `ban` and `mute` commands
- removed unecessary debug console output