### PR TITLE
release 0.15.0 prep

### DIFF
--- a/internal/commands/cmdban.go
+++ b/internal/commands/cmdban.go
@@ -78,6 +78,15 @@ func (c *CmdBan) Exec(args *CommandArgs) error {
 
 	var attachment string
 	repMsg, attachment = util.ExtractImageURLFromMessage(repMsg, args.Message.Attachments)
+	if attachment != "" {
+		img, err := util.DownloadImageFromURL(attachment)
+		if err == nil && img != nil {
+			if err = args.CmdHandler.db.SaveImageData(img); err != nil {
+				return err
+			}
+			attachment = img.ID.String()
+		}
+	}
 
 	acceptMsg := util.AcceptMessage{
 		Embed: &discordgo.MessageEmbed{
@@ -104,7 +113,7 @@ func (c *CmdBan) Exec(args *CommandArgs) error {
 				},
 			},
 			Image: &discordgo.MessageEmbedImage{
-				URL: attachment,
+				URL: util.GetImageLink(attachment, args.CmdHandler.config.WebServer.PublicAddr),
 			},
 		},
 		Session:        args.Session,
@@ -114,6 +123,7 @@ func (c *CmdBan) Exec(args *CommandArgs) error {
 			rep, err := shared.PushBan(
 				args.Session,
 				args.CmdHandler.db,
+				args.CmdHandler.config.WebServer.PublicAddr,
 				args.Guild.ID,
 				args.User.ID,
 				victim.User.ID,
@@ -124,7 +134,7 @@ func (c *CmdBan) Exec(args *CommandArgs) error {
 				util.SendEmbedError(args.Session, args.Channel.ID,
 					"Failed banning member: ```\n"+err.Error()+"\n```")
 			} else {
-				args.Session.ChannelMessageSendEmbed(args.Channel.ID, rep.AsEmbed())
+				args.Session.ChannelMessageSendEmbed(args.Channel.ID, rep.AsEmbed(args.CmdHandler.config.WebServer.PublicAddr))
 			}
 		},
 	}

--- a/internal/commands/cmdmute.go
+++ b/internal/commands/cmdmute.go
@@ -236,6 +236,20 @@ func (c *CmdMute) muteUnmute(args *CommandArgs) error {
 		return err
 	}
 
+	repMsg := strings.Join(args.Args[1:], " ")
+
+	var attachment string
+	repMsg, attachment = util.ExtractImageURLFromMessage(repMsg, args.Message.Attachments)
+	if attachment != "" {
+		img, err := util.DownloadImageFromURL(attachment)
+		if err == nil && img != nil {
+			if err = args.CmdHandler.db.SaveImageData(img); err != nil {
+				return err
+			}
+			attachment = img.ID.String()
+		}
+	}
+
 	rep, err := shared.PushMute(
 		args.Session,
 		args.CmdHandler.db,
@@ -244,7 +258,7 @@ func (c *CmdMute) muteUnmute(args *CommandArgs) error {
 		args.User.ID,
 		victim.User.ID,
 		strings.Join(args.Args[1:], " "),
-		"",
+		attachment,
 		muteRoleID)
 
 	if err != nil {

--- a/internal/commands/cmdmute.go
+++ b/internal/commands/cmdmute.go
@@ -239,6 +239,7 @@ func (c *CmdMute) muteUnmute(args *CommandArgs) error {
 	rep, err := shared.PushMute(
 		args.Session,
 		args.CmdHandler.db,
+		args.CmdHandler.config.WebServer.PublicAddr,
 		args.Guild.ID,
 		args.User.ID,
 		victim.User.ID,
@@ -250,7 +251,7 @@ func (c *CmdMute) muteUnmute(args *CommandArgs) error {
 		_, err = util.SendEmbedError(args.Session, args.Channel.ID,
 			"Failed creating report: ```\n"+err.Error()+"\n```")
 	} else {
-		_, err = args.Session.ChannelMessageSendEmbed(args.Channel.ID, rep.AsEmbed())
+		_, err = args.Session.ChannelMessageSendEmbed(args.Channel.ID, rep.AsEmbed(args.CmdHandler.config.WebServer.PublicAddr))
 	}
 
 	return err

--- a/internal/commands/cmdtest.go
+++ b/internal/commands/cmdtest.go
@@ -1,5 +1,11 @@
 package commands
 
+import (
+	"fmt"
+
+	"github.com/zekroTJA/shinpuru/internal/util"
+)
+
 type CmdTest struct {
 }
 
@@ -24,6 +30,8 @@ func (c *CmdTest) GetDomainName() string {
 }
 
 func (c *CmdTest) Exec(args *CommandArgs) error {
-	// args.Message.Attachments
-	return nil
+	imgURL := args.Message.Attachments[0].URL
+	fmt.Println(imgURL)
+	image, _ := util.DownloadImageFromURL(imgURL)
+	return args.CmdHandler.db.SaveImageData(image)
 }

--- a/internal/commands/cmdtest.go
+++ b/internal/commands/cmdtest.go
@@ -24,8 +24,6 @@ func (c *CmdTest) GetDomainName() string {
 }
 
 func (c *CmdTest) Exec(args *CommandArgs) error {
-	// fmt.Println(args.Session.Channel("549575608074502174"))
-
-	// return args.CmdHandler.bck.RestoreBackup(args.Guild.ID, "6499313859982409728", )
-	return args.CmdHandler.bck.HardFlush(args.Guild.ID)
+	// args.Message.Attachments
+	return nil
 }

--- a/internal/commands/cmdvote.go
+++ b/internal/commands/cmdvote.go
@@ -212,7 +212,7 @@ func (c *CmdVote) Exec(args *CommandArgs) error {
 		Description:   description,
 		Possibilities: split[1:],
 		ImageURL:      imgLink,
-		Ticks:         make([]*util.VoteTick, 0),
+		Ticks:         make(map[string]*util.VoteTick),
 	}
 	emb, err := vote.AsEmbed(args.Session)
 	if err != nil {

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -97,6 +97,10 @@ type Database interface {
 	SetSession(key, userID string, expires time.Time) error
 	GetSession(key string) (string, error)
 	DeleteSession(userID string) error
+
+	GetImageData(id snowflake.ID) (*Image, error)
+	SaveImageData(image *Image) error
+	RemoveImageData(id snowflake.ID) error
 }
 
 func IsErrDatabaseNotFound(err error) bool {

--- a/internal/core/database.go
+++ b/internal/core/database.go
@@ -98,8 +98,8 @@ type Database interface {
 	GetSession(key string) (string, error)
 	DeleteSession(userID string) error
 
-	GetImageData(id snowflake.ID) (*Image, error)
-	SaveImageData(image *Image) error
+	GetImageData(id snowflake.ID) (*util.Image, error)
+	SaveImageData(image *util.Image) error
 	RemoveImageData(id snowflake.ID) error
 }
 

--- a/internal/core/imgsave.go
+++ b/internal/core/imgsave.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/bwmarrin/snowflake"
+)
+
+var defClient = http.Client{
+	CheckRedirect: func(r *http.Request, via []*http.Request) error {
+		r.URL.Opaque = r.URL.Path
+		return nil
+	},
+}
+
+type Image struct {
+	ID       snowflake.ID
+	MimeType string
+	Data     []byte
+	Size     int
+}
+
+func DownloadImageFromURL(url string) (*Image, error) {
+	resp, err := defClient.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	img := new(Image)
+
+	img.MimeType = resp.Header.Get("Content-Type")
+	if img.MimeType == "" {
+		return nil, fmt.Errorf("mime type not received")
+	}
+
+	img.Data, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	img.Size = len(img.Data)
+
+	if img.Data == nil || img.Size < 1 {
+		return nil, fmt.Errorf("empty body received")
+	}
+
+	return img, nil
+}

--- a/internal/core/mysql.go
+++ b/internal/core/mysql.go
@@ -132,10 +132,11 @@ func (m *MySQL) setup() {
 	_, err = m.DB.Exec("CREATE TABLE IF NOT EXISTS `imagestore` (" +
 		"`iid` int(11) NOT NULL AUTO_INCREMENT," +
 		"`id` text NOT NULL," +
-		"`mineType` string NOT NULL," +
+		"`mimeType` text NOT NULL," +
 		"`data` longblob NOT NULL," +
 		"PRIMARY KEY (`iid`)" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
+	mErr.Append(err)
 
 	if mErr.Len() > 0 {
 		util.Log.Fatalf("Failed database setup: %s", mErr.Concat().Error())
@@ -840,8 +841,8 @@ func (m *MySQL) DeleteSession(userID string) error {
 	return err
 }
 
-func (m *MySQL) GetImageData(id snowflake.ID) (*Image, error) {
-	img := new(Image)
+func (m *MySQL) GetImageData(id snowflake.ID) (*util.Image, error) {
+	img := new(util.Image)
 	row := m.DB.QueryRow("SELECT id, mimeType, data FROM imagestore WHERE id = ?", id)
 	err := row.Scan(&img.ID, &img.MimeType, &img.Data)
 	if err == sql.ErrNoRows {
@@ -856,7 +857,7 @@ func (m *MySQL) GetImageData(id snowflake.ID) (*Image, error) {
 	return img, nil
 }
 
-func (m *MySQL) SaveImageData(img *Image) error {
+func (m *MySQL) SaveImageData(img *util.Image) error {
 	_, err := m.DB.Exec("INSERT INTO imagestore (id, mimeType, data) VALUES (?, ?, ?)", img.ID, img.MimeType, img.Data)
 	return err
 }

--- a/internal/core/mysql.go
+++ b/internal/core/mysql.go
@@ -129,6 +129,14 @@ func (m *MySQL) setup() {
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
 	mErr.Append(err)
 
+	_, err = m.DB.Exec("CREATE TABLE IF NOT EXISTS `imagestore` (" +
+		"`iid` int(11) NOT NULL AUTO_INCREMENT," +
+		"`id` text NOT NULL," +
+		"`mineType` string NOT NULL," +
+		"`data` longblob NOT NULL," +
+		"PRIMARY KEY (`iid`)" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;")
+
 	if mErr.Len() > 0 {
 		util.Log.Fatalf("Failed database setup: %s", mErr.Concat().Error())
 	}
@@ -826,6 +834,35 @@ func (m *MySQL) GetSession(key string) (string, error) {
 
 func (m *MySQL) DeleteSession(userID string) error {
 	_, err := m.DB.Exec("DELETE FROM sessions WHERE userID = ?", userID)
+	if err == sql.ErrNoRows {
+		return ErrDatabaseNotFound
+	}
+	return err
+}
+
+func (m *MySQL) GetImageData(id snowflake.ID) (*Image, error) {
+	img := new(Image)
+	row := m.DB.QueryRow("SELECT id, mimeType, data FROM imagestore WHERE id = ?", id)
+	err := row.Scan(&img.ID, &img.MimeType, &img.Data)
+	if err == sql.ErrNoRows {
+		return nil, ErrDatabaseNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	img.Size = len(img.Data)
+
+	return img, nil
+}
+
+func (m *MySQL) SaveImageData(img *Image) error {
+	_, err := m.DB.Exec("INSERT INTO imagestore (id, mimeType, data) VALUES (?, ?, ?)", img.ID, img.MimeType, img.Data)
+	return err
+}
+
+func (m *MySQL) RemoveImageData(id snowflake.ID) error {
+	_, err := m.DB.Exec("DELETE FROM imagestore WHERE id = ?", id)
 	if err == sql.ErrNoRows {
 		return ErrDatabaseNotFound
 	}

--- a/internal/core/sqlite.go
+++ b/internal/core/sqlite.go
@@ -826,4 +826,40 @@ func (m *Sqlite) DeleteSession(userID string) error {
 	return err
 }
 
-// TODO: implement imagestore
+func (m *Sqlite) GetImageData(id snowflake.ID) (*util.Image, error) {
+	// img := new(util.Image)
+	// row := m.DB.QueryRow("SELECT id, mimeType, data FROM imagestore WHERE id = ?", id)
+	// err := row.Scan(&img.ID, &img.MimeType, &img.Data)
+	// if err == sql.ErrNoRows {
+	// 	return nil, ErrDatabaseNotFound
+	// }
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// img.Size = len(img.Data)
+
+	// return img, nil
+
+	// TODO: implementation
+	return nil, nil
+}
+
+func (m *Sqlite) SaveImageData(img *util.Image) error {
+	// _, err := m.DB.Exec("INSERT INTO imagestore (id, mimeType, data) VALUES (?, ?, ?)", img.ID, img.MimeType, img.Data)
+	// return err
+
+	// TODO: implementation
+	return nil
+}
+
+func (m *Sqlite) RemoveImageData(id snowflake.ID) error {
+	// _, err := m.DB.Exec("DELETE FROM imagestore WHERE id = ?", id)
+	// if err == sql.ErrNoRows {
+	// 	return ErrDatabaseNotFound
+	// }
+	// return err
+
+	// TODO: implementation
+	return nil
+}

--- a/internal/core/sqlite.go
+++ b/internal/core/sqlite.go
@@ -825,3 +825,5 @@ func (m *Sqlite) DeleteSession(userID string) error {
 	}
 	return err
 }
+
+// TODO: implement imagestore

--- a/internal/shared/reports.go
+++ b/internal/shared/reports.go
@@ -8,7 +8,7 @@ import (
 	"github.com/zekroTJA/shinpuru/internal/util"
 )
 
-func PushReport(s *discordgo.Session, db core.Database, guildID, executorID, victimID, reason, attachment string, typ int) (*util.Report, error) {
+func PushReport(s *discordgo.Session, db core.Database, publicAddr, guildID, executorID, victimID, reason, attachment string, typ int) (*util.Report, error) {
 	repID := util.NodesReport[typ].Generate()
 
 	rep := &util.Report{
@@ -27,21 +27,21 @@ func PushReport(s *discordgo.Session, db core.Database, guildID, executorID, vic
 	}
 
 	if modlogChan, err := db.GetGuildModLog(guildID); err == nil {
-		s.ChannelMessageSendEmbed(modlogChan, rep.AsEmbed())
+		s.ChannelMessageSendEmbed(modlogChan, rep.AsEmbed(publicAddr))
 	}
 
 	dmChan, err := s.UserChannelCreate(victimID)
 	if err == nil {
-		s.ChannelMessageSendEmbed(dmChan.ID, rep.AsEmbed())
+		s.ChannelMessageSendEmbed(dmChan.ID, rep.AsEmbed(publicAddr))
 	}
 
 	return rep, nil
 }
 
-func PushKick(s *discordgo.Session, db core.Database, guildID, executorID, victimID, reason, attachment string) (*util.Report, error) {
+func PushKick(s *discordgo.Session, db core.Database, publicAddr, guildID, executorID, victimID, reason, attachment string) (*util.Report, error) {
 	const typ = 0
 
-	rep, err := PushReport(s, db, guildID, executorID, victimID, reason, attachment, typ)
+	rep, err := PushReport(s, db, publicAddr, guildID, executorID, victimID, reason, attachment, typ)
 	if err != nil {
 		return nil, err
 	}
@@ -54,10 +54,10 @@ func PushKick(s *discordgo.Session, db core.Database, guildID, executorID, victi
 	return rep, nil
 }
 
-func PushBan(s *discordgo.Session, db core.Database, guildID, executorID, victimID, reason, attachment string) (*util.Report, error) {
+func PushBan(s *discordgo.Session, db core.Database, publicAddr, guildID, executorID, victimID, reason, attachment string) (*util.Report, error) {
 	const typ = 1
 
-	rep, err := PushReport(s, db, guildID, executorID, victimID, reason, attachment, typ)
+	rep, err := PushReport(s, db, publicAddr, guildID, executorID, victimID, reason, attachment, typ)
 	if err != nil {
 		return nil, err
 	}
@@ -70,14 +70,14 @@ func PushBan(s *discordgo.Session, db core.Database, guildID, executorID, victim
 	return rep, nil
 }
 
-func PushMute(s *discordgo.Session, db core.Database, guildID, executorID, victimID, reason, attachment, muteRoleID string) (*util.Report, error) {
+func PushMute(s *discordgo.Session, db core.Database, publicAddr, guildID, executorID, victimID, reason, attachment, muteRoleID string) (*util.Report, error) {
 	const typ = 2
 
 	if reason == "" {
 		reason = "no reason specified"
 	}
 
-	rep, err := PushReport(s, db, guildID, executorID, victimID, reason, attachment, typ)
+	rep, err := PushReport(s, db, publicAddr, guildID, executorID, victimID, reason, attachment, typ)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/imgstore.go
+++ b/internal/util/imgstore.go
@@ -1,9 +1,10 @@
-package core
+package util
 
 import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/bwmarrin/snowflake"
 )
@@ -46,5 +47,15 @@ func DownloadImageFromURL(url string) (*Image, error) {
 		return nil, fmt.Errorf("empty body received")
 	}
 
+	img.ID = NodeImages.Generate()
+
 	return img, nil
+}
+
+func GetImageLink(ident, publicAddr string) string {
+	if ident == "" || strings.HasPrefix(ident, "http://") || strings.HasPrefix(ident, "https://") {
+		return ident
+	}
+
+	return fmt.Sprintf("%s/imagestore/%s.png", publicAddr, ident)
 }

--- a/internal/util/report.go
+++ b/internal/util/report.go
@@ -22,7 +22,7 @@ func (r *Report) GetTimestamp() time.Time {
 	return time.Unix(r.ID.Time()/1000, 0)
 }
 
-func (r *Report) AsEmbed() *discordgo.MessageEmbed {
+func (r *Report) AsEmbed(publicAddr string) *discordgo.MessageEmbed {
 	return &discordgo.MessageEmbed{
 		Title: "Case " + r.ID.String(),
 		Color: ReportColors[r.Type],
@@ -48,15 +48,15 @@ func (r *Report) AsEmbed() *discordgo.MessageEmbed {
 		},
 		Timestamp: r.GetTimestamp().Format("2006-01-02T15:04:05.000Z"),
 		Image: &discordgo.MessageEmbedImage{
-			URL: r.AttachmehtURL,
+			URL: GetImageLink(r.AttachmehtURL, publicAddr),
 		},
 	}
 }
 
-func (r *Report) AsEmbedField() *discordgo.MessageEmbedField {
+func (r *Report) AsEmbedField(publicAddr string) *discordgo.MessageEmbedField {
 	attachmentTxt := ""
 	if r.AttachmehtURL != "" {
-		attachmentTxt = fmt.Sprintf("Attachment: [[open](%s)]\n", r.AttachmehtURL)
+		attachmentTxt = fmt.Sprintf("Attachment: [[open](%s)]\n", GetImageLink(r.AttachmehtURL, publicAddr))
 	}
 
 	return &discordgo.MessageEmbedField{

--- a/internal/util/snowflakenodes.go
+++ b/internal/util/snowflakenodes.go
@@ -6,6 +6,7 @@ var NodesReport []*snowflake.Node
 var NodeBackup *snowflake.Node
 var NodeLCHandler *snowflake.Node
 var NodeTags *snowflake.Node
+var NodeImages *snowflake.Node
 
 func SetupSnowflakeNodes() error {
 	NodesReport = make([]*snowflake.Node, len(ReportTypes))
@@ -20,6 +21,7 @@ func SetupSnowflakeNodes() error {
 	NodeBackup, err = snowflake.NewNode(100)
 	NodeLCHandler, err = snowflake.NewNode(110)
 	NodeTags, err = snowflake.NewNode(120)
+	NodeImages, err = snowflake.NewNode(130)
 
 	return err
 }

--- a/internal/webserver/helper.go
+++ b/internal/webserver/helper.go
@@ -115,7 +115,7 @@ func getIPAddr(ctx *routing.Context) string {
 func (ws *WebServer) handlerFiles(ctx *routing.Context) error {
 	path := string(ctx.Path())
 
-	if strings.HasPrefix(path, "/api") || strings.HasPrefix(path, "/_/") {
+	if strings.HasPrefix(path, "/api") || strings.HasPrefix(path, "/imagestore") || strings.HasPrefix(path, "/_/") {
 		ctx.Next()
 		return nil
 	}

--- a/internal/webserver/objects.go
+++ b/internal/webserver/objects.go
@@ -206,8 +206,9 @@ func MemberFromMember(m *discordgo.Member) *Member {
 	}
 }
 
-func ReportFromReport(r *util.Report) *Report {
+func ReportFromReport(r *util.Report, publicAddr string) *Report {
 	rtype := util.ReportTypes[r.Type]
+	r.AttachmehtURL = util.GetImageLink(r.AttachmehtURL, publicAddr)
 	return &Report{
 		Report:   r,
 		TypeName: rtype,

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -91,11 +91,19 @@ func NewWebServer(db core.Database, s *discordgo.Session, cmd *commands.CmdHandl
 }
 
 func (ws *WebServer) registerHandlers() {
-	// rlGlobal := ws.rlm.GetHandler(500*time.Millisecond, 50)
-	// rlUsersCreate := ws.rlm.GetHandler(15*time.Second, 1)
-	// rlPageCreate := ws.rlm.GetHandler(5*time.Second, 5)
+	// --------------------------------
+	// AVAILABLE WITHOUT AUTH
 
-	ws.router.Use(ws.addHeaders, ws.optionsHandler, ws.auth.checkAuth, ws.handlerFiles)
+	ws.router.Use(ws.addHeaders, ws.optionsHandler)
+
+	imagestore := ws.router.Group("/imagestore")
+	imagestore.
+		Get("/<id>", ws.handlerGetImage)
+
+	// --------------------------------
+	// ONLY AVAILABLE AFTER AUTH
+
+	ws.router.Use(ws.auth.checkAuth, ws.handlerFiles)
 
 	ws.router.Get(endpointLogInWithDC, ws.dcoauth.HandlerInit)
 	ws.router.Get(endpointAuthCB, ws.dcoauth.HandlerCallback)


### PR DESCRIPTION
- attachments *(as message attachment or as link passed to the description)* to reports are now downlaoded by shinpuru and saved in the database so that images attached to reports are safely provided by shinpurus web server instead of using external sources
- attachments can now also be made to chat mutes
- vote tick desicions can now be edited  
![](https://i.zekro.de/2019-10-14_15-16-45.gif)