### PR TITLE
Port of cmds to slashcommands

### DIFF
--- a/internal/inits/commandhandler.go
+++ b/internal/inits/commandhandler.go
@@ -39,6 +39,7 @@ func InitCommandHandler(container di.Container) (k *ken.Ken, err error) {
 		new(slashcommands.Backup),
 		new(slashcommands.Ban),
 		new(slashcommands.Bug),
+		new(slashcommands.Clear),
 		new(slashcommands.Vote),
 	)
 	if err != nil {

--- a/internal/inits/commandhandler.go
+++ b/internal/inits/commandhandler.go
@@ -37,6 +37,7 @@ func InitCommandHandler(container di.Container) (k *ken.Ken, err error) {
 	err = k.RegisterCommands(
 		new(slashcommands.Autorole),
 		new(slashcommands.Backup),
+		new(slashcommands.Ban),
 		new(slashcommands.Vote),
 	)
 	if err != nil {

--- a/internal/inits/ltctimer.go
+++ b/internal/inits/ltctimer.go
@@ -50,6 +50,9 @@ func InitLTCTimer(container di.Container) lctimer.LifeCycleTimer {
 			return "@every 60s"
 		},
 		func() {
+			if tnw == nil {
+				return
+			}
 			if err := tnw.Handle(); err != nil {
 				logrus.WithError(err).Error("LCT :: failed executing twitch notify handler")
 			}

--- a/internal/slashcommands/ban.go
+++ b/internal/slashcommands/ban.go
@@ -160,7 +160,7 @@ func (c *Ban) Run(ctx *ken.Ctx) (err error) {
 		},
 	}
 
-	if _, err = acceptMsg.Send(ctx.Event.ChannelID); err != nil {
+	if _, err = acceptMsg.AsFollowUp(ctx); err != nil {
 		return err
 	}
 

--- a/internal/slashcommands/ban.go
+++ b/internal/slashcommands/ban.go
@@ -80,6 +80,10 @@ func (c *Ban) SubDomains() []permissions.SubPermission {
 }
 
 func (c *Ban) Run(ctx *ken.Ctx) (err error) {
+	if err = ctx.Defer(); err != nil {
+		return
+	}
+
 	victim := ctx.Event.ApplicationCommandData().Options[0].UserValue(nil)
 
 	if victim.ID == ctx.User().ID {
@@ -123,22 +127,6 @@ func (c *Ban) Run(ctx *ken.Ctx) (err error) {
 			"Please enter a valid report description.").
 			DeleteAfter(8 * time.Second).Error()
 	}
-
-	/* attachments cannot be send in a slash command at this stage of time
-	repMsg, attachment = imgstore.ExtractFromMessage(repMsg, ctx.GetMessage().Attachments)
-	if attachment != "" {
-		img, err := imgstore.DownloadFromURL(attachment)
-		if err == nil && img != nil {
-			st, _ := ctx.GetObject(static.DiObjectStorage).(storage.Storage)
-			err = st.PutObject(static.StorageBucketImages, img.ID.String(),
-				bytes.NewReader(img.Data), int64(img.Size), img.MimeType)
-			if err != nil {
-				return err
-			}
-			attachment = img.ID.String()
-		}
-	}
-	*/
 
 	cfg, _ := ctx.Get(static.DiConfig).(config.Provider)
 	repSvc, _ := ctx.Get(static.DiReport).(*report.ReportService)

--- a/internal/slashcommands/ban.go
+++ b/internal/slashcommands/ban.go
@@ -1,0 +1,180 @@
+package slashcommands
+
+import (
+	"bytes"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/zekroTJA/shinpuru/internal/models"
+	"github.com/zekroTJA/shinpuru/internal/services/config"
+	"github.com/zekroTJA/shinpuru/internal/services/permissions"
+	"github.com/zekroTJA/shinpuru/internal/services/report"
+	"github.com/zekroTJA/shinpuru/internal/services/storage"
+	"github.com/zekroTJA/shinpuru/internal/util"
+	"github.com/zekroTJA/shinpuru/internal/util/imgstore"
+	"github.com/zekroTJA/shinpuru/internal/util/static"
+	"github.com/zekroTJA/shinpuru/pkg/acceptmsg"
+	"github.com/zekroTJA/shinpuru/pkg/timeutil"
+	"github.com/zekrotja/ken"
+)
+
+type Ban struct{}
+
+var (
+	_ ken.Command             = (*Ban)(nil)
+	_ permissions.PermCommand = (*Ban)(nil)
+)
+
+func (c *Ban) Name() string {
+	return "ban"
+}
+
+func (c *Ban) Description() string {
+	return "Ban users with creating a report entry."
+}
+
+func (c *Ban) Version() string {
+	return ""
+}
+
+func (c *Ban) Type() discordgo.ApplicationCommandType {
+	return discordgo.ChatApplicationCommand
+}
+
+func (c *Ban) Options() []*discordgo.ApplicationCommandOption {
+	return []*discordgo.ApplicationCommandOption{
+		{
+			Type:        discordgo.ApplicationCommandOptionUser,
+			Name:        "user",
+			Description: "User to ban",
+			Required:    true,
+		},
+		{
+			Type:        discordgo.ApplicationCommandOptionString,
+			Name:        "reason",
+			Description: "Ban reason",
+			Required:    true,
+		},
+		{
+			Type:        discordgo.ApplicationCommandOptionString,
+			Name:        "attachment",
+			Description: "Url of an image attachment (e.g. a screenshot)",
+			Required:    false,
+		},
+		{
+			Type:        discordgo.ApplicationCommandOptionString,
+			Name:        "timeout",
+			Description: "duration of the ban",
+			Required:    false,
+		},
+	}
+}
+
+func (c *Ban) Domain() string {
+	return "sp.guild.mod.ban"
+}
+
+func (c *Ban) SubDomains() []permissions.SubPermission {
+	return nil
+}
+
+func (c *Ban) Run(ctx *ken.Ctx) (err error) {
+	victim := ctx.Event.ApplicationCommandData().Options[0].UserValue(nil)
+
+	if victim.ID == ctx.User().ID {
+		return util.SendEmbedError(ctx.Session, ctx.Event.ChannelID,
+			"You can not ban yourself...").
+			DeleteAfter(8 * time.Second).Error()
+	}
+
+	reason := ctx.Event.ApplicationCommandData().Options[1].StringValue()
+
+	var attachment string = ""
+	var timeout time.Duration = 0
+
+	//parse options 2 and 3 (attachment and timeout)
+	for i := 2; i <= 3; i++ {
+		if len(ctx.Event.ApplicationCommandData().Options) > i {
+			switch ctx.Event.ApplicationCommandData().Options[i].Name {
+			case "Attachment":
+				attachment = ctx.Event.ApplicationCommandData().Options[i].StringValue()
+			case "Timeout":
+				timeout, _ = time.ParseDuration(ctx.Event.ApplicationCommandData().Options[i].StringValue())
+			}
+		}
+	}
+
+	if attachment != "" {
+		img, err := imgstore.DownloadFromURL(attachment)
+		if err == nil && img != nil {
+			st, _ := ctx.Get(static.DiObjectStorage).(storage.Storage)
+			err = st.PutObject(static.StorageBucketImages, img.ID.String(),
+				bytes.NewReader(img.Data), int64(img.Size), img.MimeType)
+			if err != nil {
+				return err
+			}
+			attachment = img.ID.String()
+		}
+	}
+
+	if strings.TrimSpace(reason) == "" {
+		return util.SendEmbedError(ctx.Session, ctx.Event.ChannelID,
+			"Please enter a valid report description.").
+			DeleteAfter(8 * time.Second).Error()
+	}
+
+	/* attachments cannot be send in a slash command at this stage of time
+	repMsg, attachment = imgstore.ExtractFromMessage(repMsg, ctx.GetMessage().Attachments)
+	if attachment != "" {
+		img, err := imgstore.DownloadFromURL(attachment)
+		if err == nil && img != nil {
+			st, _ := ctx.GetObject(static.DiObjectStorage).(storage.Storage)
+			err = st.PutObject(static.StorageBucketImages, img.ID.String(),
+				bytes.NewReader(img.Data), int64(img.Size), img.MimeType)
+			if err != nil {
+				return err
+			}
+			attachment = img.ID.String()
+		}
+	}
+	*/
+
+	cfg, _ := ctx.Get(static.DiConfig).(config.Provider)
+	repSvc, _ := ctx.Get(static.DiReport).(*report.ReportService)
+
+	rep := &models.Report{
+		GuildID:       ctx.Event.GuildID,
+		ExecutorID:    ctx.User().ID,
+		VictimID:      victim.ID,
+		Msg:           reason,
+		AttachmehtURL: attachment,
+		Timeout:       timeutil.NowAddPtr(timeout),
+	}
+
+	emb := rep.AsEmbed(cfg.Config().WebServer.PublicAddr)
+	emb.Title = "Report Check"
+	emb.Description = "Is everything okay so far?"
+
+	acceptMsg := acceptmsg.AcceptMessage{
+		Embed:          emb,
+		Session:        ctx.Session,
+		UserID:         ctx.User().ID,
+		DeleteMsgAfter: true,
+		AcceptFunc: func(msg *discordgo.Message) (err error) {
+			rep, err := repSvc.PushBan(rep)
+
+			if err != nil {
+				return
+			}
+			_, err = ctx.Session.ChannelMessageSendEmbed(ctx.Event.ChannelID, rep.AsEmbed(cfg.Config().WebServer.PublicAddr))
+			return
+		},
+	}
+
+	if _, err = acceptMsg.Send(ctx.Event.ChannelID); err != nil {
+		return err
+	}
+
+	return acceptMsg.Error()
+}

--- a/internal/slashcommands/bug.go
+++ b/internal/slashcommands/bug.go
@@ -70,5 +70,5 @@ func (c *Bug) Run(ctx *ken.Ctx) (err error) {
 		},
 	}
 	_, err = ctx.Session.ChannelMessageSendEmbed(ctx.Event.ChannelID, emb)
-	return err
+	return
 }

--- a/internal/slashcommands/bug.go
+++ b/internal/slashcommands/bug.go
@@ -69,6 +69,7 @@ func (c *Bug) Run(ctx *ken.Ctx) (err error) {
 			},
 		},
 	}
-	_, err = ctx.Session.ChannelMessageSendEmbed(ctx.Event.ChannelID, emb)
+	err = ctx.FollowUpEmbed(emb).Error
+
 	return
 }

--- a/internal/slashcommands/clear.go
+++ b/internal/slashcommands/clear.go
@@ -176,7 +176,7 @@ func (c *Clear) selected(ctx *ken.SubCommandCtx) (err error) {
 					fmt.Sprintf("Deleted %d %s.", len(msgIds), util.Pluralize(len(msgIds), "message")), "", static.ColorEmbedUpdated).
 					DeleteAfter(6 * time.Second).Error()
 			}).
-			Send(ctx.Event.ChannelID)
+			AsFollowUp(ctx.Ctx)
 		return
 	}
 
@@ -201,7 +201,7 @@ func (c *Clear) selected(ctx *ken.SubCommandCtx) (err error) {
 					fmt.Sprintf("Deleted %d %s.", len(msgIds), util.Pluralize(len(msgIds), "message")), "", static.ColorEmbedUpdated).
 					DeleteAfter(6 * time.Second).Error()
 			}).
-			Send(ctx.Event.ChannelID)
+			AsFollowUp(ctx.Ctx)
 		return
 	}
 
@@ -228,9 +228,11 @@ func (c *Clear) delete(ctx *ken.SubCommandCtx, msglist []*discordgo.Message) (er
 		return err
 	}
 
-	return util.SendEmbed(ctx.Session, ctx.Event.ChannelID,
-		fmt.Sprintf("Deleted %d %s.", len(msgs)-1, util.Pluralize(len(msgs)-1, "message")), "", static.ColorEmbedUpdated).
-		DeleteAfter(6 * time.Second).Error()
+	return ctx.FollowUpEmbed(&discordgo.MessageEmbed{
+		Description: fmt.Sprintf("Deleted %d %s.", len(msgs)-1, util.Pluralize(len(msgs)-1, "message")),
+		Title:       "",
+		Color:       static.ColorEmbedUpdated,
+	}).Error
 }
 
 func (c *Clear) iterMsgsWithReactionFromUser(

--- a/internal/slashcommands/clear.go
+++ b/internal/slashcommands/clear.go
@@ -93,7 +93,7 @@ func (c *Clear) Run(ctx *ken.Ctx) (err error) {
 }
 
 func (c *Clear) last(ctx *ken.SubCommandCtx) (err error) {
-	msglist, err := ctx.Session.ChannelMessages(ctx.Event.ChannelID, 1, "", "", "")
+	msglist, err := ctx.Session.ChannelMessages(ctx.Event.ChannelID, 2, "", "", "")
 	if err != nil {
 		return err
 	}
@@ -108,9 +108,9 @@ func (c *Clear) amount(ctx *ken.SubCommandCtx) (err error) {
 		user = ctx.Options()[1].UserValue(nil)
 	}
 
-	if amount < 1 || amount > 100 {
+	if amount < 1 || amount > 99 {
 		return util.SendEmbedError(ctx.Session, ctx.Event.ChannelID,
-			"Number of messages is invald and must be between *(including)* 1 and *(including)* 100.").
+			"Number of messages is invald and must be between *(including)* 1 and 100.").
 			DeleteAfter(8 * time.Second).Error()
 	}
 

--- a/internal/slashcommands/clear.go
+++ b/internal/slashcommands/clear.go
@@ -1,0 +1,263 @@
+package slashcommands
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/zekroTJA/shinpuru/internal/services/permissions"
+	"github.com/zekroTJA/shinpuru/internal/util"
+	"github.com/zekroTJA/shinpuru/internal/util/static"
+	"github.com/zekroTJA/shinpuru/pkg/acceptmsg"
+	"github.com/zekroTJA/shinpuru/pkg/fetch"
+	"github.com/zekrotja/ken"
+)
+
+type Clear struct{}
+
+var (
+	_ ken.Command             = (*Clear)(nil)
+	_ permissions.PermCommand = (*Clear)(nil)
+)
+
+func (c *Clear) Name() string {
+	return "clear"
+}
+
+func (c *Clear) Description() string {
+	return "Clear messages in a channel."
+}
+
+func (c *Clear) Version() string {
+	return "1.0.0"
+}
+
+func (c *Clear) Type() discordgo.ApplicationCommandType {
+	return discordgo.ChatApplicationCommand
+}
+
+func (c *Clear) Options() []*discordgo.ApplicationCommandOption {
+	return []*discordgo.ApplicationCommandOption{
+		{
+			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			Name:        "last",
+			Description: "Clears the last message",
+		},
+		{
+			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			Name:        "amount",
+			Description: "Clear a specified amount of messages",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionInteger,
+					Name:        "amount",
+					Description: "Amount of messages to clear",
+					Required:    true,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionInteger,
+					Name:        "user",
+					Description: "Clear messages send by this User",
+					Required:    false,
+				},
+			},
+		},
+		{
+			Type:        discordgo.ApplicationCommandOptionSubCommand,
+			Name:        "selected",
+			Description: "Removes either messages selected with ❌ emote by you or all messages below the 🔻 emote by you",
+		},
+	}
+}
+
+func (c *Clear) Domain() string {
+	return "sp.guild.mod.clear"
+}
+
+func (c *Clear) SubDomains() []permissions.SubPermission {
+	return nil
+}
+
+func (c *Clear) Run(ctx *ken.Ctx) (err error) {
+	if err = ctx.Defer(); err != nil {
+		return
+	}
+
+	err = ctx.HandleSubCommands(
+		ken.SubCommandHandler{"last", c.last},
+		ken.SubCommandHandler{"amount", c.amount},
+		ken.SubCommandHandler{"selected", c.selected},
+	)
+
+	return
+}
+
+func (c *Clear) last(ctx *ken.SubCommandCtx) (err error) {
+	msglist, err := ctx.Session.ChannelMessages(ctx.Event.ChannelID, 1, "", "", "")
+	if err != nil {
+		return err
+	}
+	return c.delete(ctx, msglist)
+}
+
+func (c *Clear) amount(ctx *ken.SubCommandCtx) (err error) {
+
+	amount := ctx.Options()[0].IntValue()
+	var user *discordgo.User
+	if len(ctx.Options()) > 1 {
+		user = ctx.Options()[1].UserValue(nil)
+	}
+
+	if amount < 1 || amount > 100 {
+		return util.SendEmbedError(ctx.Session, ctx.Event.ChannelID,
+			"Number of messages is invald and must be between *(including)* 1 and *(including)* 100.").
+			DeleteAfter(8 * time.Second).Error()
+	}
+
+	var member *discordgo.Member
+	if user != nil {
+		member, err = fetch.FetchMember(ctx.Session, ctx.Event.GuildID, user.ID)
+		if err != nil {
+			return util.SendEmbedError(ctx.Session, ctx.Event.ChannelID,
+				"Sorry, but the member can not be found on this guild. :cry:").
+				DeleteAfter(8 * time.Second).Error()
+		}
+	}
+	msglistUnfiltered, err := ctx.Session.ChannelMessages(ctx.Event.ChannelID, int(amount), "", "", "")
+	if err != nil {
+		return err
+	}
+
+	var msglist []*discordgo.Message
+	if member != nil {
+		for _, m := range msglistUnfiltered {
+			if m.Author.ID == member.User.ID {
+				msglist = append(msglist, m)
+			}
+		}
+	} else {
+		msglist = msglistUnfiltered
+	}
+
+	return c.delete(ctx, msglist)
+}
+
+func (c *Clear) selected(ctx *ken.SubCommandCtx) (err error) {
+	msgs, err := ctx.Session.ChannelMessages(ctx.Event.ChannelID, 100, "", "", "")
+	if err != nil {
+		return
+	}
+
+	var deleteAfterMsg *discordgo.Message
+	var deleteAfterIdx int
+	c.iterMsgsWithReactionFromUser(ctx.Session, msgs, "🔻", ctx.User().ID, func(m *discordgo.Message, i int) bool {
+		deleteAfterMsg = m
+		deleteAfterIdx = i
+		return false
+	})
+
+	if deleteAfterMsg != nil {
+		msgIds := make([]string, 0, deleteAfterIdx+1)
+		for _, m := range msgs[0 : deleteAfterIdx+1] {
+			msgIds = append(msgIds, m.ID)
+		}
+
+		_, err = acceptmsg.New().
+			WithSession(ctx.Session).
+			WithContent(
+				fmt.Sprintf("Do you really want to delete all %d messages to message %s?", len(msgIds), deleteAfterMsg.ID)).
+			LockOnUser(ctx.User().ID).
+			DeleteAfterAnswer().
+			DoOnAccept(func(m *discordgo.Message) (err error) {
+				if err = ctx.Session.ChannelMessagesBulkDelete(ctx.Event.ChannelID, msgIds); err != nil {
+					return
+				}
+				return util.SendEmbed(ctx.Session, ctx.Event.ChannelID,
+					fmt.Sprintf("Deleted %d %s.", len(msgIds), util.Pluralize(len(msgIds), "message")), "", static.ColorEmbedUpdated).
+					DeleteAfter(6 * time.Second).Error()
+			}).
+			Send(ctx.Event.ChannelID)
+		return
+	}
+
+	msgIds := make([]string, 0, len(msgs))
+	c.iterMsgsWithReactionFromUser(ctx.Session, msgs, "❌", ctx.User().ID, func(m *discordgo.Message, i int) bool {
+		msgIds = append(msgIds, m.ID)
+		return true
+	})
+
+	if len(msgIds) > 0 {
+		_, err = acceptmsg.New().
+			WithSession(ctx.Session).
+			WithContent(
+				fmt.Sprintf("Do you really want to delete all %d selected messages?", len(msgIds))).
+			LockOnUser(ctx.User().ID).
+			DeleteAfterAnswer().
+			DoOnAccept(func(m *discordgo.Message) (err error) {
+				if err = ctx.Session.ChannelMessagesBulkDelete(ctx.Event.ChannelID, msgIds); err != nil {
+					return
+				}
+				return util.SendEmbed(ctx.Session, ctx.Event.ChannelID,
+					fmt.Sprintf("Deleted %d %s.", len(msgIds), util.Pluralize(len(msgIds), "message")), "", static.ColorEmbedUpdated).
+					DeleteAfter(6 * time.Second).Error()
+			}).
+			Send(ctx.Event.ChannelID)
+		return
+	}
+
+	return util.SendEmbedError(ctx.Session, ctx.Event.ChannelID,
+		"No message was either selected by you with the 🔻 emote nor was any with the ❌ emote.\n\n"+
+			"**Explaination:**\n"+
+			"You can either select single messages to be deleted with the ❌ emote or select a message with the 🔻 emote "+
+			"and this message plus all messages sent after this message will be deleted after entering the `clear selected` command.").
+		DeleteAfter(12 * time.Second).Error()
+}
+
+func (c *Clear) delete(ctx *ken.SubCommandCtx, msglist []*discordgo.Message) (err error) {
+	if err != nil {
+		return err
+	}
+
+	msgs := make([]string, len(msglist))
+	for i, m := range msglist {
+		msgs[i] = m.ID
+	}
+
+	err = ctx.Session.ChannelMessagesBulkDelete(ctx.Event.ChannelID, msgs)
+	if err != nil {
+		return err
+	}
+
+	return util.SendEmbed(ctx.Session, ctx.Event.ChannelID,
+		fmt.Sprintf("Deleted %d %s.", len(msgs)-1, util.Pluralize(len(msgs)-1, "message")), "", static.ColorEmbedUpdated).
+		DeleteAfter(6 * time.Second).Error()
+}
+
+func (c *Clear) iterMsgsWithReactionFromUser(
+	s *discordgo.Session,
+	msgs []*discordgo.Message,
+	name, userID string,
+	action func(*discordgo.Message, int) bool,
+) (err error) {
+	for i, m := range msgs {
+	reactionLoop:
+		for _, r := range m.Reactions {
+			if r.Emoji.Name == name {
+				rUsers, err := s.MessageReactions(m.ChannelID, m.ID, name, 100, "", "")
+				if err != nil {
+					return err
+				}
+				for _, rUser := range rUsers {
+					if rUser.ID == userID {
+						if !action(m, i) {
+							return nil
+						}
+						break reactionLoop
+					}
+				}
+			}
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
The commands
- Ban
- Bug
- Clear

are ported to the new slashcommand system.
It is pretty much a 1-to-1 port. (E.g. most code is copied from the old versions).

Also fixed a bug, that the bot would crash if no twitchnotifier were used.

part of https://github.com/zekroTJA/shinpuru/issues/290